### PR TITLE
change local outpost image name to outpost:tell-us to avoid conflicts

### DIFF
--- a/docker-compose.outpost.local.yml
+++ b/docker-compose.outpost.local.yml
@@ -53,7 +53,7 @@ services:
   # Outpost app
 
   outpost:
-    image: "outpost:development"
+    image: "outpost:tell-us"
     env_file:
       - ./outpost/.env
     # command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
if you also happen to work on outpost locally outpost:development outpost:production images will already exist, small change to make things easier since this particulr setup is quite specific to one way of working.