### PR TITLE
BSP-41 / Updates to provider experience

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -23,13 +23,13 @@ class EmployeesController < ApplicationController
   def show
   end
 
-  def update
-    if params[:commit] == 'confirm_details'
+  def update  
+    if params[:confirm_details] == 'true'
       @employee.touch(:updated_at)
       redirect_to employees_path, notice: 'Employee details confirmed.'
     else
       if @employee.update(employee_params)
-        redirect_to employees_path
+        redirect_to employees_path, notice: 'Employee updated successfully.'
       else
         render "show"
       end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -24,10 +24,15 @@ class EmployeesController < ApplicationController
   end
 
   def update
-    if @employee.update(employee_params)
-      redirect_to employees_path
+    if params[:commit] == 'confirm_details'
+      @employee.touch(:updated_at)
+      redirect_to employees_path, notice: 'Employee details confirmed.'
     else
-      render "show"
+      if @employee.update(employee_params)
+        redirect_to employees_path
+      else
+        render "show"
+      end
     end
   end
 

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -163,8 +163,12 @@
 </div>
 
 <div class="form-actions">
-    <%= f.button "Continue", class: "button" %>
-    <%= f.button "All details are correct. No updates required.", name: 'commit', value: 'confirm_details', class: "button button--secondary" %>
+  <div class="field checkbox">
+    <%= hidden_field_tag 'confirm_details', 'false' %>
+    <%= check_box_tag 'confirm_details', 'true', false, id: "confirm_details", class: "checkbox__input", style: "z-index: 10" %>
+    <%= label_tag :confirm_details, "All details are correct.", class: "checkbox__label" %>
+  </div>
+  <%= f.button "Continue", class: "button", id: "submit_form" %>
 </div>
 
 <% end %>

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -164,6 +164,7 @@
 
 <div class="form-actions">
     <%= f.button "Continue", class: "button" %>
+    <%= f.button "All details are correct. No updates required.", name: 'commit', value: 'confirm_details', class: "button" %>
 </div>
 
 <% end %>

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -164,7 +164,7 @@
 
 <div class="form-actions">
     <%= f.button "Continue", class: "button" %>
-    <%= f.button "All details are correct. No updates required.", name: 'commit', value: 'confirm_details', class: "button" %>
+    <%= f.button "All details are correct. No updates required.", name: 'commit', value: 'confirm_details', class: "button button--secondary" %>
 </div>
 
 <% end %>


### PR DESCRIPTION
Adds a checkbox on the employee form to confirm that employee details are already correct. This is designed to allow providers to ‘update’ their records even when all remain the same - update ‘last updated’ date for example.
![image](https://github.com/wearefuturegov/tell-us-who-you-employ/assets/107464669/7d591eba-121b-45b2-bfa2-c082f3438ad1)
