### PR TITLE
BSP- 47/ Add number of staff filter

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -9,7 +9,8 @@ class Admin::ServicesController < Admin::BaseController
       persistence_id: false,
       select_options: {
         service: Service.options_for_service,
-        sorted_by: Service.options_for_sorted_by
+        sorted_by: Service.options_for_sorted_by,
+        with_employee_count_range: Service.options_for_number_of_staff
       },
     ) or return
     

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -46,11 +46,18 @@ include PgSearch::Model
     case sort_option.to_s
     when /^service_/
       order(services[:name].lower.send(direction))
-    when /^staff_count_/
+    # when /^staff_count_/
       # order(employees[:qualifications].lower.send(direction))
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end
+  }
+
+  scope :with_employee_count_range, ->(range_key) {
+    where(id: Service.select("services.id")
+                     .joins(:employees)
+                     .group("services.id")
+                     .having(employee_count_condition_subquery(range_key)))
   }
 
 
@@ -64,7 +71,8 @@ include PgSearch::Model
     available_filters: [
       :search,
       :service,
-      :sorted_by
+      :sorted_by,
+      :with_employee_count_range,
     ]
   )
 
@@ -79,6 +87,29 @@ include PgSearch::Model
     end
   end
 
+  def self.options_for_number_of_staff
+    {
+      '0-5' => '0-5',
+      '6-10' => '6-10',
+      '10-20' => '10-20',
+      '20+' => '20+'
+    }
+  end
+
+  def self.employee_count_condition_subquery(range_key)
+    case range_key
+    when '0-5'
+      "COUNT(employees.id) BETWEEN 0 AND 5"
+    when '6-10'
+      "COUNT(employees.id) BETWEEN 6 AND 10"
+    when '10-20'
+      "COUNT(employees.id) BETWEEN 11 AND 20"
+    when '20+'
+      "COUNT(employees.id) > 20"
+    else
+      "1=1"
+    end
+  end
 
   # def self.options_for_location
   #   Service.find_each.map do |service|

--- a/app/views/admin/services/_filters.html.erb
+++ b/app/views/admin/services/_filters.html.erb
@@ -11,6 +11,8 @@
       <%= f.label :service, "Provider", class: "visually-hidden" %>
       <%= f.select :service, @filterrific.select_options[:service], { include_blank: 'Filter by Provider' }, { class: "filters__select", data: { autosubmit: true }} %>
 
+      <%= f.label :with_employee_count_range, "Number of staff", class: "visually-hidden" %>
+      <%= f.select :with_employee_count_range, @filterrific.select_options[:with_employee_count_range], { include_blank: 'Filter by Number of staff' }, { class: "filters__select", data: { autosubmit: true }} %>
     </div>
   </details>
 

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     street_address { FFaker::AddressUK.street_address }
     postal_code { FFaker::AddressUK.postcode }
     date_of_birth { FFaker::Time.date(year_latest: 18, year_range: 65 - 18) }
-    employed_from { FFaker::Time.date(year_range: 25.years.ago, to: Date.today) }
+    employed_from { FFaker::Time.date(year_latest: 18, year_range: 65 - 18) }
     job_title { FFaker::Job.title }
     currently_employed { true }
   end

--- a/spec/features/admin_managing_services_spec.rb
+++ b/spec/features/admin_managing_services_spec.rb
@@ -71,6 +71,14 @@ RSpec.feature 'Admin managing services' do
 
         expect(page).to have_content(service_1.name)
       end
+
+      scenario 'you filter by number of staff' do
+        find('details.filters').click
+        select '0-5', from: 'filterrific[with_employee_count_range]'
+        find('#search-button').click
+
+        expect(page).to have_content(service_1.name)
+      end
     end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -20,10 +20,41 @@ RSpec.describe Service, type: :model do
 
   describe 'scopes' do
     describe '.service' do
+      let!(:service_1) { FactoryBot.create :service, name: 'Service 1' }
       it 'returns services with the given name' do
-        service = Service.create(name: 'Service Name')
-        expect(Service.service('Service Name')).to include(service)
+        expect(Service.service('Service 1')).to match_array([service_1])
       end
+    end
+  end
+
+  describe '.sorted_by' do
+    let!(:service_1) { FactoryBot.create :service, name: 'Service 1' }
+    let!(:service_2) { FactoryBot.create :service, name: 'Service 2' }
+    let!(:employee_1) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_2) { FactoryBot.create :employee, service: service_2 }
+    it 'returns services sorted by name in ascending order' do
+      expect(Service.sorted_by('service_asc')).to eq([service_1, service_2])
+    end
+
+    it 'returns services sorted by name in descending order' do
+      expect(Service.sorted_by('service_desc')).to eq([service_2, service_1])
+    end
+  end
+
+  describe '.with_employee_count_range' do
+    let!(:service_1) { FactoryBot.create :service, name: 'Service 1' }
+    let!(:service_2) { FactoryBot.create :service, name: 'Service 2' }
+    let!(:employee_1) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_2) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_3) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_4) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_5) { FactoryBot.create :employee, service: service_1 }
+    let!(:employee_6) { FactoryBot.create :employee, service: service_1 }
+
+    it 'returns services with the specified employee count range' do    
+      expect(service_1.employees.count).to eq(6)
+      expect(service_2.employees.count).to eq(0)
+      expect(Service.with_employee_count_range('6-10')).to match_array([service_1])
     end
   end
 end


### PR DESCRIPTION
[JIRA ticket](https://tpximpact.atlassian.net/jira/software/projects/BSP/boards/7?selectedIssue=BSP-47)

This PR adds a Number of Staff filter to the Provider view. The user can choose the values between 0-5, 6-10, 10-20, and 20+.

![image](https://github.com/wearefuturegov/tell-us-who-you-employ/assets/107464669/0f12fbf6-90cc-4d6b-a89c-4762db152bdd)
