### PR TITLE
BSP-48/ Add 'Last Updated' to services view

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,7 +12,7 @@ class Employee < ApplicationRecord
   # ----------
   # associations
   # ----------
-  belongs_to :service
+  belongs_to :service, touch: true
 
 
   # ----------

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,7 +10,7 @@ class Service < ApplicationRecord
  # ----------
   # associations
   # ----------
-  has_many :employees, dependent: :destroy
+  has_many :employees
   attribute :name, :string
 
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,7 +10,7 @@ class Service < ApplicationRecord
  # ----------
   # associations
   # ----------
-  has_many :employees
+  has_many :employees, dependent: :destroy
   attribute :name, :string
 
 
@@ -48,6 +48,8 @@ include PgSearch::Model
       order(services[:name].lower.send(direction))
     when /^staff_count_/
       # order(employees[:qualifications].lower.send(direction))
+    when /^updated_at_/
+      order(services[:updated_at].send(direction))
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end

--- a/app/views/admin/services/_list.html.erb
+++ b/app/views/admin/services/_list.html.erb
@@ -4,6 +4,7 @@
       <th class="visually-hidden">ID</th>
       <%= sort_column_by("Provider", "service") %>
       <th>Number of staff</th>
+      <%= sort_column_by("Last updated", "updated_at")%>
       <th class="visually-hidden">Actions</th>
     </tr>
   </thead>
@@ -17,6 +18,8 @@
         <td>
           <%= s.employees.count %>
         </td>
+        <td>
+          <%= s.updated_at.strftime("%d %b %Y") %>
         <td>
           <a href="<%= ENV["OAUTH_SERVER"] %>/admin/services/<%= s.id %>">Outpost service page</a>
         </td>

--- a/db/migrate/20240228104107_add_timestamps_to_services.rb
+++ b/db/migrate/20240228104107_add_timestamps_to_services.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToServices < ActiveRecord::Migration[6.1]
+  def change
+    add_timestamps :services, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_21_104456) do
+ActiveRecord::Schema.define(version: 2024_02_28_104107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 2024_02_21_104456) do
 
   create_table "services", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
This PR adds a 'Last Updated' column to the View By Provider view. The column has been added to the `sort_by` method so that users can sort by the `updated_at` column.
I've added the `touch: true` option to the `belongs_to :service` association in the Employee model. This ensures that any creation, update, or deletion of an employee record will automatically update the updated_at timestamp of the associated service.



![image](https://github.com/wearefuturegov/tell-us-who-you-employ/assets/107464669/20a0a6b9-8cf5-4f98-9fa4-87b8e6104fec)
