### PR TITLE
Fix styling issue on qualifications list

### DIFF
--- a/app/views/admin/employees/_list.html.erb
+++ b/app/views/admin/employees/_list.html.erb
@@ -37,7 +37,7 @@
           <%= link_to e.service.name.truncate(30), admin_service_path(e.service.id), title: e.service.name %>
         </td>
         <td>
-          <%= e.qualifications.join("<br>") if e.qualifications.present? %>
+          <%= safe_join(e.qualifications, tag(:br)) if e.qualifications.present? %>
         </td>
         <td><%= status_tag(e.currently_employed? ? 'Active' : 'Inactive') %></td>
         <td>


### PR DESCRIPTION
Fix styling issue where `<br>` tags were displaying in the list of qualifications. Fixed by using `safe_join` helper which is safer than using `html_safe`, as it prevents potential XSS vulnerabilities by escaping the content of the array elements, only marking the <br> tags as HTML.

![image](https://github.com/wearefuturegov/tell-us-who-you-employ/assets/107464669/e01e737a-2189-48d3-a478-82f52e28eeb9)
