### PR TITLE
BSP-53 / Fix History section and additional test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,20 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def current_user
+    if session[:first_name] && session[:last_name]
+      @current_user ||= [session[:first_name], session[:last_name]].join(' ')
+    else
+      nil
+    end
+  end
+  
+
+  def user_for_paper_trail
+    current_user
+  end
+
+
   # moved here from sessions_controller since an admin might also need to submit employee data
   # First check that the user is associated with an organisation and has listed
   # services; if they haven't, they can't use this service

--- a/app/views/admin/employees/edit.html.erb
+++ b/app/views/admin/employees/edit.html.erb
@@ -286,14 +286,24 @@
     </div>
 
     <div class="collapsible" id="history">
-        <button class="collapsible__header" type="button">
-            <h2>
-              History
-            </h2>
-        </button>
-        <div class="collapsible__content">
-
+      <button class="collapsible__header" type="button">
+          <h2>
+            History
+          </h2>
+      </button>
+      <div class="collapsible__content">
+        <ul>
+          <% @employee.versions.each do |version| %>
+            <li>
+              <%= 'Record updated ' if version.event == 'update' %>
+              <%= 'Record created ' if version.event == 'create' %>
+              by <%= version.whodunnit || "Unknown User" %><br>
+              Date: <%= version.created_at.strftime("%d-%m-%Y %H:%M:%S") %><br>
+            </li>
+          <% end %>
+        </ul>
         </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/employees/edit.html.erb
+++ b/app/views/admin/employees/edit.html.erb
@@ -302,7 +302,6 @@
             </li>
           <% end %>
         </ul>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/admin/employees/show.html.erb
+++ b/app/views/admin/employees/show.html.erb
@@ -241,31 +241,23 @@
         </div>
     </div>
 
-    <div class="collapsible" id="history">
-        <button class="collapsible__header" type="button">
-            <h2>
-              History
-            </h2>
-        </button>
-        <div class="collapsible__content">
-          <ul>
-            <% @employee.versions.each do |version| %>
-              <li>
-                Changed on: <%= version.created_at.strftime("%Y-%m-%d %H:%M:%S") %><br>
-                Changed by: <%= version.whodunnit || "Unknown" %><br> <!-- Directly display whodunnit -->
-                <% if version.changeset.present? %>
-                  Changes:
-                  <ul>
-                    <% version.changeset.each do |key, value| %>
-                      <li>
-                        <%= key.humanize %>: <%= value[0] %> -> <%= value[1] %>
-                      </li>
-                    <% end %>
-                  </ul>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
+      <div class="collapsible" id="history">
+          <button class="collapsible__header" type="button">
+              <h2>
+                History
+              </h2>
+          </button>
+          <div class="collapsible__content">
+            <ul>
+              <% @employee.versions.each do |version| %>
+                <li>
+                  <%= 'Record updated ' if version.event == 'update' %>
+                  <%= 'Record created ' if version.event == 'create' %>
+                  by <%= version.whodunnit || "Unknown User" %><br>
+                  Date: <%= version.created_at.strftime("%d-%m-%Y %H:%M:%S") %><br>
+                </li>
+              <% end %>
+            </ul>
 
         </div>
     </div>

--- a/app/views/admin/employees/show.html.erb
+++ b/app/views/admin/employees/show.html.erb
@@ -241,25 +241,24 @@
         </div>
     </div>
 
-      <div class="collapsible" id="history">
-          <button class="collapsible__header" type="button">
-              <h2>
-                History
-              </h2>
-          </button>
-          <div class="collapsible__content">
-            <ul>
-              <% @employee.versions.each do |version| %>
-                <li>
-                  <%= 'Record updated ' if version.event == 'update' %>
-                  <%= 'Record created ' if version.event == 'create' %>
-                  by <%= version.whodunnit || "Unknown User" %><br>
-                  Date: <%= version.created_at.strftime("%d-%m-%Y %H:%M:%S") %><br>
-                </li>
-              <% end %>
-            </ul>
-
-        </div>
+    <div class="collapsible" id="history">
+        <button class="collapsible__header" type="button">
+            <h2>
+              History
+            </h2>
+        </button>
+        <div class="collapsible__content">
+          <ul>
+            <% @employee.versions.each do |version| %>
+              <li>
+                <%= 'Record updated ' if version.event == 'update' %>
+                <%= 'Record created ' if version.event == 'create' %>
+                by <%= version.whodunnit || "Unknown User" %><br>
+                Date: <%= version.created_at.strftime("%d-%m-%Y %H:%M:%S") %><br>
+              </li>
+            <% end %>
+          </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/spec/tasks/process_permanent_deletions_spec.rake
+++ b/spec/tasks/process_permanent_deletions_spec.rake
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'process_permanent_deletions' do
+  let!(:employee_1) { FactoryBot.create :employee, marked_for_deletion: Time.now, currently_employed: false }
+  let!(:employee_2) { FactoryBot.create :employee, marked_for_deletion: Time.now, currently_employed: false }
+  let!(:employee_3) { FactoryBot.create :employee, marked_for_deletion: Time.now, currently_employed: false }
+  let!(:employee_4) { FactoryBot.create :employee, marked_for_deletion: nil, currently_employed: true }
+
+  it 'decreases the count of employees' do
+    employees_count = Employee.count
+
+    process_permanent_deletions()
+
+    expect(Employee.count).to eq(employees_count - 3)
+
+  it 'increments destroyed_employees_count' do
+    destroyed_employees_count = 0
+
+    process_permanent_deletions()
+
+    expect(destroyed_employees_count).to eq(3)
+  end
+
+  it 'does not destroy employees not marked for deletion' do
+    process_permanent_deletions()
+
+    expect(Employee.find(employee_4.id)).to be_present
+  end
+end


### PR DESCRIPTION
- Add test for Rake task for employees who are marked for deletion.
- Configure papertrail to store the full name of the User who makes changes to Employee records, using "whodunnit". 
- Both the show and edit pages now show the employee record history.
![image](https://github.com/wearefuturegov/tell-us-who-you-employ/assets/107464669/468fc562-d6c6-40c0-aa47-2434b1283c81)
